### PR TITLE
Fixed content URL

### DIFF
--- a/Metadata.json
+++ b/Metadata.json
@@ -1,7 +1,7 @@
 {
     "Author": "Kranthi Kumar",
     "ContentSize": 8114,
-    "ContentUrl": "https://github.com/azureautomation/Create-Automation-Windows-HybridWorker/blob/main/Create-Windows-HW.ps1",
+    "ContentUrl": "https://raw.githubusercontent.com/azureautomation/Create-Automation-Windows-HybridWorker/main/Create-Windows-HW.ps1",
     "DownloadCount": 0,
     "Id": "azureautomation/Create-Automation-Windows-HybridWorker",
     "IsFederated": true,


### PR DESCRIPTION
The current content url is incorrect leading to a broken experience on portal.
![image](https://user-images.githubusercontent.com/41619136/108466908-6639c180-72aa-11eb-8142-164a9da17769.png)


This change will fix the issue.